### PR TITLE
Change address representation

### DIFF
--- a/NoC/FaultInjector.vhd
+++ b/NoC/FaultInjector.vhd
@@ -10,7 +10,7 @@ USE ieee.math_real.ALL;
 
 entity FaultInjector is
 generic(
-    address: regmetadeflit
+    address: regflit
 );
 port(
     clock:          in std_logic;
@@ -71,7 +71,7 @@ begin
         variable seed1, seed2: positive;               -- Seed values for random generator
         variable rand: real;                           -- Random real-number value in range 0 to 1.0
     begin
-        file_open(file_pointer,"fault_00"&to_hstring(address)&".txt",READ_MODE);
+        file_open(file_pointer,"fault_"&to_hstring(address)&".txt",READ_MODE);
         while not endfile(file_pointer) loop
 
             -- limpa a string tmp_word

--- a/NoC/NOC.vhd
+++ b/NoC/NOC.vhd
@@ -36,7 +36,7 @@ begin
 
     Router: for i in 0 to (NROT-1) generate
         n : Entity work.RouterCC
-        generic map( address => NUMBER_TO_ADDRESS(i)((METADEFLIT-1) downto 0))
+        generic map( address => ADDRESS_FROM_INDEX(i))
         port map(
             clock                   => clock(i),
             reset                   => reset,

--- a/NoC/Phoenix_buffer.vhd
+++ b/NoC/Phoenix_buffer.vhd
@@ -36,7 +36,7 @@ use STD.textio.all;
 
 -- interface da Phoenix_buffer
 entity Phoenix_buffer is
-	generic(address : regmetadeflit := (others=>'0');
+	generic(address : regflit := (others=>'0');
 		bufLocation: integer := 0);
 port(
 	clock:      in  std_logic;
@@ -329,14 +329,14 @@ begin
 
 						-- se o primeiro flit do pacote a ser transmitido possui o bit indicando que eh um pacote de controle E se nesse primeiro flit possui o endereco do roteador em que o buffer se encontra
 						-- OU se devo criar um pacote de controle com a tabela de falhas (este pacote eh criado se for pedido a leitura da tabela de falhas)
-						if((buf(CONV_INTEGER(first))(TAM_FLIT-1)='1') and (buf(CONV_INTEGER(first))((METADEFLIT - 1) downto 0)=address)) or c_createmessage = '1' then -- PACOTE DE CONTROLE
+						if((buf(CONV_INTEGER(first))(TAM_FLIT-1)='1') and (buf(CONV_INTEGER(first))((TAM_FLIT-2) downto 0)=address((TAM_FLIT-2) downto 0))) or c_createmessage = '1' then -- PACOTE DE CONTROLE
 							
 							-- se preciso criar um pacote com a tabela de falhas. Comentario antigo: o pacote de controle pare este roteador
 							if c_createmessage = '1' then
 
 								-- se ultimo pacote de controle recebido foi de leitura da tabela de falhas
 								if codigoControl = c_RD_FAULT_TAB_STEP1 then
-									c_Buffer <=  x"80" & address((METADEFLIT-1) downto 0); -- entao crio o primeiro flit do pacote que vai conter a tabela de falhas
+									c_Buffer <=  '1' & address((TAM_FLIT-2) downto 0); -- entao crio o primeiro flit do pacote que vai conter a tabela de falhas
 									h <= '1';         -- requisicao de chaveamento (chavear os dados de entrada para a porta de saida atraves da crossbar)
 									EA <= S_HEADER;   -- maquina de estados avanca para o estado S_HEADER
 									eh_controle <= '1'; -- indica que o pacote lido/criado eh de controle
@@ -631,7 +631,7 @@ begin
 								if (data_ack = '1') then
 		
 									case (indexFlitCtrl) is
-										when 1 => c_Buffer <= x"00" & address; -- neste quarto flit havera o endereco do roteador
+										when 1 => c_Buffer <= address; -- neste quarto flit havera o endereco do roteador
 
 										when 2 => c_Buffer((TAM_FLIT-1) downto METADEFLIT) <= CONV_STD_LOGIC_VECTOR(0,METADEFLIT-2) & c_TabelaFalhas(EAST)((3*COUNTERS_SIZE+1) downto 3*COUNTERS_SIZE);
 											  c_Buffer((METADEFLIT-1) downto 0) <= CONV_STD_LOGIC_VECTOR(0,METADEFLIT-COUNTERS_SIZE) & c_TabelaFalhas(EAST)((3*COUNTERS_SIZE-1) downto 2*COUNTERS_SIZE);

--- a/NoC/Phoenix_package.vhd
+++ b/NoC/Phoenix_package.vhd
@@ -119,12 +119,10 @@ package PhoenixPackage is
     function CONV_STRING_8BITS( dado : std_logic_vector(7 downto 0)) return string;
     function CONV_STRING_16BITS( dado : std_logic_vector(15 downto 0)) return string;
     function CONV_STRING_32BITS( dado : std_logic_vector(31 downto 0)) return string;
-    function NUMBER_TO_ADDRESS(number: integer) return regflit;
-    function ADDRESS_TO_NUMBER (address: std_logic_vector) return integer;
-    function ADDRESS_TO_NUMBER_NOIA (address: std_logic_vector) return integer;
+    function INDEX_FROM_ADDRESS (address: std_logic_vector) return integer;
     function to_hstring(value: std_logic_vector) return string;
     function PORT_NAME(value: integer) return string;
-    function GET_ADDR(index : integer) return regflit;
+    function ADDRESS_FROM_INDEX(index : integer) return regflit;
     function OR_REDUCTION(arrayN : std_logic_vector ) return boolean;
 
 end PhoenixPackage;
@@ -134,7 +132,7 @@ package body PhoenixPackage is
     --
     -- dado o index do roteador retorna o endereço correspondente
     --
-    function GET_ADDR( index: integer) return regflit is
+    function ADDRESS_FROM_INDEX( index: integer) return regflit is
         variable addrX, addrY: regmetadeflit;
         variable addr: regflit;
     begin
@@ -142,7 +140,7 @@ package body PhoenixPackage is
         addrY := CONV_STD_LOGIC_VECTOR(index mod NUM_Y, METADEFLIT); 
         addr := addrX & addrY;
         return addr;
-    end GET_ADDR;
+    end ADDRESS_FROM_INDEX;
     --
     -- converte um inteiro em um std_logic_vector(2 downto 0)
     --
@@ -256,36 +254,16 @@ package body PhoenixPackage is
         return str;
     end CONV_STRING_32BITS;
     
-    function NUMBER_TO_ADDRESS( number: integer ) return regflit is
-        variable address: regflit := (others => '0');
-    begin
-        address(TAM_FLIT-1 downto METADEFLIT) := (others=>'0');
-        address(METADEFLIT-1 downto QUARTOFLIT) := CONV_STD_LOGIC_VECTOR(number/NUM_X, QUARTOFLIT);
-        address(QUARTOFLIT-1 downto 0) := CONV_STD_LOGIC_VECTOR(number mod NUM_Y, QUARTOFLIT);
-        return address;
-    end NUMBER_TO_ADDRESS;
-    
-    function ADDRESS_TO_NUMBER (address: std_logic_vector) return integer is
+    function INDEX_FROM_ADDRESS (address: std_logic_vector) return integer is
         variable number: integer := 0;
-        alias addrX is address(METADEFLIT-1 downto QUARTOFLIT);
-        alias addrY is address(QUARTOFLIT-1 downto 0);
+        alias addrX is address(TAM_FLIT-1 downto METADEFLIT);
+        alias addrY is address(METADEFLIT-1 downto 0);
         variable X : integer := CONV_INTEGER(addrX);
         variable Y : integer := CONV_INTEGER(addrY);
     begin
-        number := Y*(MAX_X+1) + X;
+        number := X*NUM_X + Y;
         return number;
-    end ADDRESS_TO_NUMBER;
-    
-    function ADDRESS_TO_NUMBER_NOIA (address: std_logic_vector) return integer is
-        variable number: integer := 0;
-        alias addrX is address(METADEFLIT-1 downto QUARTOFLIT);
-        alias addrY is address(QUARTOFLIT-1 downto 0);
-        variable X : integer := CONV_INTEGER(addrX);
-        variable Y : integer := CONV_INTEGER(addrY);
-    begin
-        number := X*(MAX_Y+1) + Y;
-        return number;
-    end ADDRESS_TO_NUMBER_NOIA;
+    end INDEX_FROM_ADDRESS;
     
   -- converte hexa para string
     function to_hstring (value     : STD_LOGIC_VECTOR) return STRING is

--- a/NoC/Phoenix_switchcontrol.vhd
+++ b/NoC/Phoenix_switchcontrol.vhd
@@ -5,7 +5,7 @@ use work.PhoenixPackage.all;
 use work.HammingPack16.all;
 
 entity SwitchControl is
-    generic(address : regmetadeflit := (others=>'0'));
+    generic(address : regflit := (others=>'0'));
 port(
     clock :   in  std_logic;
     reset :   in  std_logic;
@@ -44,7 +44,6 @@ architecture RoutingTable of SwitchControl is
 
 -- sinais do controle
     signal indice_dir: integer range 0 to (NPORT-1) := 0;
-    signal tx,ty: regquartoflit := (others=> '0');
     signal auxfree: regNport := (others=> '0');
     signal source:  arrayNport_reg3 := (others=> (others=> '0'));
     signal sender_ant: regNport := (others=> '0');
@@ -110,9 +109,6 @@ begin
         end case;
     end process;
 
-    tx <= header((METADEFLIT - 1) downto QUARTOFLIT); -- coordenada X do destino
-    ty <= header((QUARTOFLIT - 1) downto 0); -- coordernada Y do destino
-    
     ------------------------------------------------------------
     --gravacao da tabela de falhas
     ------------------------------------------------------------
@@ -219,7 +215,7 @@ begin
             operacao => c_CodControle, -- codigo de controle do pacote de controle (terceiro flit do pacote de controle)
             ceT => c_ce, -- chip enable da tabela de roteamento. Indica que sera escrito na tabela de roteamento
             oe => ceTable, -- usado para solicitar direcao/porta destino para a tabela de roteamento
-            dest => header((METADEFLIT - 1) downto 0), -- primeiro flit/header do pacote (contem o destino do pacote)
+            dest => header, -- primeiro flit/header do pacote (contem o destino do pacote)
             inputPort => sel, -- porta de entrada selecionada pelo arbitro para ser chaveada
             outputPort => dir, -- indica qual porta de saida o pacote sera encaminhado
             find => find -- indica se terminou de achar uma porta de saida para o pacote conforme a tabela de roteamento
@@ -255,7 +251,7 @@ begin
                 end if;
             when S2 => PES <= S3;
             when S3 => 
-                if address = header((METADEFLIT - 1) downto 0) and auxfree(LOCAL)='1' then 
+                if address = header and auxfree(LOCAL)='1' then 
                     indice_dir <= LOCAL; 
                     PES <= S4;
                 elsif(find = validRegion)then
@@ -304,7 +300,7 @@ begin
 
                 -- Aguarda resposta da Tabela                    
                 when S3 =>
-                    if address /= header((METADEFLIT - 1) downto 0) then
+                    if address /= header then
                         ceTable <= '1';
                     end if;
 

--- a/NoC/RouterCC.vhd
+++ b/NoC/RouterCC.vhd
@@ -49,7 +49,7 @@ use ieee.numeric_std.all;
 USE ieee.math_real.ALL;   -- for UNIFORM, TRUNC functions
 
 entity RouterCC is
-generic( address: regmetadeflit);
+generic( address: regflit);
 port(
 	clock:            in  std_logic;
 	reset:            in  std_logic;

--- a/topNoC.vhd
+++ b/topNoC.vhd
@@ -51,7 +51,7 @@ begin
 
     InputModules: for i in 0 to (NROT-1) generate
         IM : Entity work.inputModule
-        generic map(address => NUMBER_TO_ADDRESS(i))
+        generic map(address => ADDRESS_FROM_INDEX(i))
         port map(
             done => rx(i),
             data => data_in(i),
@@ -62,7 +62,7 @@ begin
 
     OutputModules: for i in 0 to (NROT-1) generate
         OM : Entity work.outputModule
-        generic map(address => NUMBER_TO_ADDRESS(i))
+        generic map(address => ADDRESS_FROM_INDEX(i))
         port map(
             clock => clock(i),
             tx => tx(i),


### PR DESCRIPTION
Makes address uses all flit width. The first half being the X coordinate
and the second half being the Y coordinate.

This makes the Phoenix fully compatible with the files generated by LaNoC-UFC/traffic-gen.
